### PR TITLE
Update eDensity sources for changes through season 22

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -105,6 +105,7 @@ async function loadTeams(_force=false) {
 
 	const teams = new Map();
 	for (const team of data) {
+		console.log(team)
 		if (team.current_team_status !== "active") {
 			//console.log("Skipping hidden team " + team.fullName);
 			continue;

--- a/fetch.js
+++ b/fetch.js
@@ -106,7 +106,7 @@ async function loadTeams(_force=false) {
 	const teams = new Map();
 	for (const team of data) {
 		console.log(team)
-		if (team.current_team_status !== "active") {
+		if (team.league_id === null) {
 			//console.log("Skipping hidden team " + team.fullName);
 			continue;
 		}

--- a/fetch.js
+++ b/fetch.js
@@ -252,6 +252,7 @@ async function loadTeamData(teamName, force=false) {
 		team: team_data,
 		stadium: stadium_data.get(teamName),
 		champs: team_data.championships,
+		underchamps: team_data.underchampionships,
 		runs: standings_data.runs[team_id],
 		wins: standings_data.wins[team_id],
 		net_shame: team_data.totalShamings - team_data.totalShames,

--- a/fetch.js
+++ b/fetch.js
@@ -229,7 +229,7 @@ async function loadTeamData(teamName, force=false) {
 	);
 
 	let player_ids = [];
-	for (key of ["lineup", "rotation", "bench", "bullpen"]) {
+	for (key of ["lineup", "rotation", "shadows"]) {
 		player_ids = player_ids.concat(team_data[key]);
 	}
 

--- a/sim.js
+++ b/sim.js
@@ -479,6 +479,8 @@ function updateSimulationData(simulation, data, noodle) {
 	console.log("noodle: " + noodle);
 	console.log("net shame: " + data.net_shame);
 
+	var light_switch = (data.stadium.renoLog.light_switch_toggle % 2 == 0) ? 1 : -1;
+
 
 	//season 12/13: players + runs + 10*wins + 5*netShame + 99*#champs + 5*grand + 5*fort + 500*filth
 	//season 14: players + runs + 10*wins + 5*netShame + 33*#champs + 100*grand + 100*fort + 500*filth + 50*parkmods
@@ -489,15 +491,17 @@ function updateSimulationData(simulation, data, noodle) {
 		{density: 5*data.net_shame, label: "Shame", color: performanceColor, tooltip: `Total Net Shame: ${data.net_shame}`},
 		{density: 33*data.champs, label: "Champs", color: performanceColor, tooltip: `Championships: ${data.champs}`},
 		// stadium stats
-		{density: 100*data.stadium.grandiosity, label: "Grandiosity", color: stadiumColor},
-		{density: 100*data.stadium.fortification, label: "Fortification", color: stadiumColor},
-		{density: 500*data.stadium.filthiness, label: "Filthiness", color: stadiumColor},
-		{density: -data.stadium.birds, label: "Birds", color: stadiumColor},
+		{density: light_switch*100*data.stadium.grandiosity, label: "Grandiosity", color: stadiumColor},
+		{density: light_switch*100*data.stadium.fortification, label: "Fortification", color: stadiumColor},
+		{density: light_switch*500*data.stadium.filthiness, label: "Filthiness", color: stadiumColor},
+		{density: light_switch*-data.stadium.birds, label: "Birds", color: stadiumColor},
+		{density: light_switch*-0.1*(data.stadium.state.air_balloons || 0), label: "Air Balloons", color: stadiumColor},
+		{density: light_switch*-10*(data.stadium.state.flood_balloons || 0), label: "Flood Balloons", color: stadiumColor},
 	];
 
 	for (mod of data.stadium.mods) {
 		// stadium mods
-		bodies.push({density: 50, label: mod, color: stadiumColor});
+		bodies.push({density: light_switch*50, label: mod, color: stadiumColor});
 	}
 
 	for (player of data.roster) {

--- a/sim.js
+++ b/sim.js
@@ -478,6 +478,7 @@ function updateSimulationData(simulation, data, noodle) {
 	console.log("wins: " + data.wins);
 	console.log("runs: " + data.runs);
 	console.log("champs: " + data.champs);
+	console.log("underchamps: " + data.underchamps);
 	console.log("noodle: " + noodle);
 	console.log("net shame: " + data.net_shame);
 
@@ -491,6 +492,7 @@ function updateSimulationData(simulation, data, noodle) {
 		{density: 10*data.wins, label: "Wins", color: performanceColor, tooltip: `Total Wins: ${data.wins}`},
 		{density: 5*data.net_shame, label: "Shame", color: performanceColor, tooltip: `Total Net Shame: ${data.net_shame}`},
 		{density: 33*data.champs, label: "Champs", color: performanceColor, tooltip: `Championships: ${data.champs}`},
+		{density: -33*data.underchamps, label: "Underchamps", color: performanceColor, tooltip: `Underchampionships: ${data.underchamps}`},
 		// stadium stats
 		{density: light_switch*500*data.stadium.filthiness, label: "Filthiness", color: stadiumColor},
 		{density: light_switch*-data.stadium.birds, label: "Birds", color: stadiumColor},

--- a/sim.js
+++ b/sim.js
@@ -469,6 +469,8 @@ const playerColor = "#0000FF";
 const performanceColor = "#FF0000";
 const stadiumColor = "#00FF00";
 
+const zeroDensityMods = ['GRAPHENE', 'OPEN_FLOOR_PLAN']
+
 function updateSimulationData(simulation, data, noodle) {
 	console.log("team: " + data.name);
 	console.log("roster.length: " + data.roster.length);
@@ -481,7 +483,6 @@ function updateSimulationData(simulation, data, noodle) {
 
 	var light_switch = ((data.stadium.renoLog.light_switch_toggle || 0) % 2 == 0) ? 1 : -1;
 
-
 	//season 12/13: players + runs + 10*wins + 5*netShame + 99*#champs + 5*grand + 5*fort + 500*filth
 	//season 14: players + runs + 10*wins + 5*netShame + 33*#champs + 100*grand + 100*fort + 500*filth + 50*parkmods
 	var bodies = [
@@ -491,17 +492,41 @@ function updateSimulationData(simulation, data, noodle) {
 		{density: 5*data.net_shame, label: "Shame", color: performanceColor, tooltip: `Total Net Shame: ${data.net_shame}`},
 		{density: 33*data.champs, label: "Champs", color: performanceColor, tooltip: `Championships: ${data.champs}`},
 		// stadium stats
-		{density: light_switch*100*data.stadium.grandiosity, label: "Grandiosity", color: stadiumColor},
-		{density: light_switch*100*data.stadium.fortification, label: "Fortification", color: stadiumColor},
 		{density: light_switch*500*data.stadium.filthiness, label: "Filthiness", color: stadiumColor},
 		{density: light_switch*-data.stadium.birds, label: "Birds", color: stadiumColor},
 		{density: light_switch*-0.1*(data.stadium.state.air_balloons || 0), label: "Air Balloons", color: stadiumColor, tooltip: `Air Balloons: ${data.stadium.state.air_balloons || 0}`},
 		{density: light_switch*-10*(data.stadium.state.flood_balloons || 0), label: "Flood Balloons", color: stadiumColor, tooltip: `Flood Balloons: ${data.stadium.state.flood_balloons || 0}`},
 	];
 
+	if (data.stadium.renoLog.open_floor_plan_mod) {
+		bodies.push({density: light_switch*5*data.stadium.grandiosity, label: "Grandiosity", color: stadiumColor,
+			tooltip: "Grandiosity (with Open Floor Plan)"})
+	} else if (data.stadium.renoLog.condensed_floor_plan_mod) {
+		bodies.push({density: light_switch*500*data.stadium.grandiosity, label: "Grandiosity", color: stadiumColor,
+			tooltip: "Grandiosity (with Condensed Floor Plan)"})
+	} else {
+		bodies.push(
+			{density: light_switch*100*data.stadium.grandiosity, label: "Grandiosity", color: stadiumColor})
+	}
+
+	if (data.stadium.renoLog.graphene_mod) {
+		bodies.push({
+			density: light_switch * 5 * data.stadium.fortification, label: "Fortification", color: stadiumColor,
+			tooltip: "Fortification (with Graphene)"
+		})
+	} else if (data.stadium.renoLog.antigraphene_mod) {
+		bodies.push({density: light_switch*500*data.stadium.fortification, label: "Fortification", color: stadiumColor,
+			tooltip: "Fortification (with Antigraphene)"})
+	} else {
+		bodies.push(
+			{density: light_switch*100*data.stadium.fortification, label: "Fortification", color: stadiumColor})
+	}
+
 	for (mod of data.stadium.mods) {
 		// stadium mods
-		bodies.push({density: light_switch*50, label: mod, color: stadiumColor});
+		if (!zeroDensityMods.includes(mod)) {
+			bodies.push({density: light_switch*50, label: mod, color: stadiumColor});
+		}
 	}
 
 	for (player of data.roster) {

--- a/sim.js
+++ b/sim.js
@@ -479,7 +479,7 @@ function updateSimulationData(simulation, data, noodle) {
 	console.log("noodle: " + noodle);
 	console.log("net shame: " + data.net_shame);
 
-	var light_switch = (data.stadium.renoLog.light_switch_toggle % 2 == 0) ? 1 : -1;
+	var light_switch = ((data.stadium.renoLog.light_switch_toggle || 0) % 2 == 0) ? 1 : -1;
 
 
 	//season 12/13: players + runs + 10*wins + 5*netShame + 99*#champs + 5*grand + 5*fort + 500*filth
@@ -495,8 +495,8 @@ function updateSimulationData(simulation, data, noodle) {
 		{density: light_switch*100*data.stadium.fortification, label: "Fortification", color: stadiumColor},
 		{density: light_switch*500*data.stadium.filthiness, label: "Filthiness", color: stadiumColor},
 		{density: light_switch*-data.stadium.birds, label: "Birds", color: stadiumColor},
-		{density: light_switch*-0.1*(data.stadium.state.air_balloons || 0), label: "Air Balloons", color: stadiumColor},
-		{density: light_switch*-10*(data.stadium.state.flood_balloons || 0), label: "Flood Balloons", color: stadiumColor},
+		{density: light_switch*-0.1*(data.stadium.state.air_balloons || 0), label: "Air Balloons", color: stadiumColor, tooltip: `Air Balloons: ${data.stadium.state.air_balloons || 0}`},
+		{density: light_switch*-10*(data.stadium.state.flood_balloons || 0), label: "Flood Balloons", color: stadiumColor, tooltip: `Flood Balloons: ${data.stadium.state.flood_balloons || 0}`},
 	];
 
 	for (mod of data.stadium.mods) {


### PR DESCRIPTION
This PR updates the eDensity sources to account for:

- The API change to how shadows players are fetched
- Light Switch
- Air and Flood balloons
- Graphine/antigraphene
- Open/closed floor plan
- Underchampionships

After this change all teams' calculated eDensity currently matches their actual eDensity.

It also hides teams which are not in a league (mostly relevant for the increasing number of pre-history teams). The game doesn't track their eDensity and their lack of stadiums breaks the visualizer. It doesn't seem worth fixing, at least for now.